### PR TITLE
Fix LoadPackageParam.processName

### DIFF
--- a/core/src/main/java/com/wind/xposed/entry/XposedModuleLoader.java
+++ b/core/src/main/java/com/wind/xposed/entry/XposedModuleLoader.java
@@ -72,7 +72,7 @@ public class XposedModuleLoader {
                         xc_loadPackageCopyOnWriteSortedSet.add(wrapper);
                         XC_LoadPackage.LoadPackageParam lpparam = new XC_LoadPackage.LoadPackageParam(xc_loadPackageCopyOnWriteSortedSet);
                         lpparam.packageName = currentApplicationInfo.packageName;
-                        lpparam.processName = currentApplicationInfo.processName;
+                        lpparam.processName = (String)Class.forName("android.app.ActivityThread").getDeclaredMethod("currentProcessName").invoke(null);
                         lpparam.classLoader = appClassLoader;
                         lpparam.appInfo = currentApplicationInfo;
                         lpparam.isFirstApplication = true;


### PR DESCRIPTION
`LoadPackageParam.processName`并不是`currentApplicationInfo.processName`而是`android.app.ActivityThread.processName`
可以查看这里
https://github.com/rovo89/XposedBridge/blob/a535c02ed9dfd53683cc0274d9f95bcb6ffb9f79/app/src/main/java/de/robv/android/xposed/XposedInit.java#L106-L130