### PR TITLE
Use `XposedBridge.BOOTCLASSLOADER` for parent classloader

### DIFF
--- a/core/src/main/java/com/wind/xposed/entry/XposedModuleEntry.java
+++ b/core/src/main/java/com/wind/xposed/entry/XposedModuleEntry.java
@@ -28,6 +28,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -95,24 +96,24 @@ public class XposedModuleEntry {
 
         // 过滤掉已经打包在apk中的module，避免同一个module被加载了两次
         if (installedModulePathList != null && installedModulePathList.size() > 0) {
-            List<String> packedModulePakcageNameList = null;
+            HashSet<String> packedModulePackageNames = null;
 
             for (String apkPath : modulePathList) {
-                if (packedModulePakcageNameList == null) {
-                    packedModulePakcageNameList = new ArrayList<>();
+                if (packedModulePackageNames == null) {
+                    packedModulePackageNames = new HashSet<>();
                 }
                 String packageName = getPackageNameByPath(context, apkPath);
                 XLog.d(TAG, "Current packed module path ----> " + apkPath + " packageName = " + packageName);
-                packedModulePakcageNameList.add(packageName);
+                packedModulePackageNames.add(packageName);
             }
 
-            if (packedModulePakcageNameList == null || packedModulePakcageNameList.size() == 0) {
+            if (packedModulePackageNames == null || packedModulePackageNames.size() == 0) {
                 modulePathList.addAll(installedModulePathList);
             } else {
                 for (String apkPath : installedModulePathList) {
                     String packageName = getPackageNameByPath(context, apkPath);
                     XLog.d(TAG, "Current installed module path ----> " + apkPath + " packageName = " + packageName);
-                    if (!packedModulePakcageNameList.contains(packageName)) {
+                    if (!packedModulePackageNames.contains(packageName)) {
                         modulePathList.add(apkPath);
                     }
                 }
@@ -120,10 +121,9 @@ public class XposedModuleEntry {
         }
 
         for (String modulePath : modulePathList) {
-            String dexPath = context.getDir("xposed_plugin_dex", Context.MODE_PRIVATE).getAbsolutePath();
             if (!TextUtils.isEmpty(modulePath)) {
-                Log.d(TAG, "Current truely loaded module path ----> " + modulePath);
-                XposedModuleLoader.loadModule(modulePath, dexPath, null, context.getApplicationInfo(), originClassLoader);
+                Log.d(TAG, "Current truly loaded module path ----> " + modulePath);
+                XposedModuleLoader.loadModule(modulePath, context.getApplicationInfo(), originClassLoader);
             }
         }
     }

--- a/core/src/main/java/com/wind/xposed/entry/XposedModuleLoader.java
+++ b/core/src/main/java/com/wind/xposed/entry/XposedModuleLoader.java
@@ -11,7 +11,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 
-import dalvik.system.DexClassLoader;
+import dalvik.system.PathClassLoader;
 import de.robv.android.xposed.IXposedHookInitPackageResources;
 import de.robv.android.xposed.IXposedHookLoadPackage;
 import de.robv.android.xposed.IXposedHookZygoteInit;
@@ -23,8 +23,7 @@ public class XposedModuleLoader {
 
     private static final String TAG = "XposedModuleLoader";
 
-    public static boolean loadModule(final String moduleApkPath, String moduleOdexDir, String moduleLibPath,
-                                 final ApplicationInfo currentApplicationInfo, ClassLoader appClassLoader) {
+    public static boolean loadModule(final String moduleApkPath, final ApplicationInfo currentApplicationInfo, ClassLoader appClassLoader) {
 
         XLog.i(TAG, "Loading modules from " + moduleApkPath);
 
@@ -33,7 +32,7 @@ public class XposedModuleLoader {
             return false;
         }
 
-        ClassLoader mcl = new DexClassLoader(moduleApkPath, moduleOdexDir, moduleLibPath, appClassLoader);
+        ClassLoader mcl = new PathClassLoader(moduleApkPath, XposedBridge.BOOTCLASSLOADER);
         InputStream is = mcl.getResourceAsStream("assets/xposed_init");
         if (is == null) {
             Log.i(TAG, "assets/xposed_init not found in the APK");


### PR DESCRIPTION
模块的`classloader`的`parent`应该是`XposedBridge.BOOTCLASSLOADER`，这样符合Xposed原来的逻辑，可以看这里https://github.com/rovo89/XposedBridge/blob/a535c02ed9dfd53683cc0274d9f95bcb6ffb9f79/app/src/main/java/de/robv/android/xposed/XposedInit.java#L525。
~这里依然保留`DexClassLoader`方便优化。另外把不同模块优化目录路径分离一下以免模块间冲突。~
这里换成了`PathClassLoader`。因为优化时候，系统会调用`dex2oat`优化，如果模块的`targetSDK`比系统的`SDK`大，会出现`Invalid version number in dex file header`的错误，进而加载模块失败。这里只能使用`PathClassLoader`，放弃模块优化。
这个可以PR还尝试解决宿主应用和模块的依赖冲突问题，如WindySha/Xpatch#60。