### PR TITLE
Disable inline

### DIFF
--- a/core/src/main/java/com/wind/xposed/entry/SandHookInitialization.java
+++ b/core/src/main/java/com/wind/xposed/entry/SandHookInitialization.java
@@ -3,6 +3,7 @@ package com.wind.xposed.entry;
 import android.content.Context;
 import android.util.Log;
 
+import com.swift.sandhook.SandHook;
 import com.wind.xposed.entry.util.XpatchUtils;
 
 import java.lang.reflect.Field;
@@ -23,6 +24,9 @@ public class SandHookInitialization {
 //        XposedCompat.context = context;
 //        XposedCompat.classLoader = context.getClassLoader();
 //        XposedCompat.isFirstApplication = true;
+        SandHook.disableVMInline();
+        SandHook.tryDisableProfile(context.getPackageName());
+        SandHook.disableDex2oatInline(false);
 
         String SandHookConfigClassName = "com.swift.sandhook.SandHookConfig";
         boolean isDebug = XpatchUtils.isApkDebugable(context);


### PR DESCRIPTION
See https://github.com/ganyao114/SandHook/blob/513df93cf7febbc4af80bed09a32cec185002544/app/src/main/java/com/swift/sandhook/MyApp.java#L40-L42

This prevents lining invalidating hooks.